### PR TITLE
Ensure build order

### DIFF
--- a/qt-pods.pro
+++ b/qt-pods.pro
@@ -3,3 +3,6 @@ SUBDIRS = \
     qt-pods-gui \
     qt-pods-cli
 include(pods-subdirs.pri)
+
+qt-pods-cli.depends = qt-pods-core
+qt-pods-gui.depends = qt-pods-core


### PR DESCRIPTION
qt-pods-gui and qt-pods-cli requires both qt-pods-core, this way we ensure that it's build first
