### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
     - sudo apt-get update -qq
 
 install:
-    - sudo apt-get install -y --force-yes build-essential g++-4.8
-    - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev
+    - sudo apt-get install -y --force-yes build-essential g++-4.8 -y
+    - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev -y
     - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
     - sudo apt-get update -qq
 
 install:
-    - sudo apt-get install -y --force-yes build-essential g++-4.8 -y
-    - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev -y
+    - sudo apt-get install -y --force-yes build-essential g++-4.8
+    - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev
     - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
     - sudo apt-get install -y --force-yes build-essential g++-4.8 -y
     - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev -y
-    - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 libqt5svg5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
+    - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 libqt5svg5 libqt5svg5-dev qttools5-dev-tools qttools5-dev qtmultimedia5-dev
 
 script:
     - qmake -qt=qt5 qt-pods.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+compiler: gcc
+
+dist: trusty
+sudo: required
+
+before_install:
+    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+    - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
+    - sudo apt-get update -qq
+
+install:
+    - sudo apt-get install -y --force-yes build-essential g++-4.8 -y
+    - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev -y
+    - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
+
+script:
+    - qmake -qt=qt5 qt-pods.pro
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
     - sudo apt-get install -y --force-yes build-essential g++-4.8 -y
     - sudo apt-get install -y --force-yes libudev-dev libts-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev libpulse-dev -y
-    - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
+    - sudo apt-get install -y --force-yes qtbase5-dev qtdeclarative5-dev libqt5gui5 libqt5svg5 qttools5-dev-tools qttools5-dev qtmultimedia5-dev
 
 script:
     - qmake -qt=qt5 qt-pods.pro

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Qt Pods](http://qt-pods.org/assets/logo.png "Qt Pods")](http://qt-pods.org)
 
+[![Build status](https://travis-ci.org/pixraider/qt-pods.svg?branch=master)](https://travis-ci.org/pixraider/qt-pods)
+
 Support this and other free software projects of mine by donating bitcoins:
 ```cpp
 1Hk5EkcZRaio4uGXSU453E1bNFTecsZEpt


### PR DESCRIPTION
CI support using travis-ci.org service.
Provide auto building with Qt 5 version from ubuntu-sdk repo.
1. Register qt-pod organization on https://travis-ci.org 
2. Switch on `qt-pods/qt-pods` project in [Travis CI user Profile](https://travis-ci.org/profile)
3. Accept pull request
4. Update README.md
   Change badge on
   `
   ...
   [![Build status](https://travis-ci.org/qt-pods/qt-pods.svg?branch=master)](https://travis-ci.org/qt-pods/qt-pods)
   ...
   `
